### PR TITLE
Modernize GitHub profile README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,58 @@
+## hey, i'm piyush
 
-![MasterHead](https://user-images.githubusercontent.com/10498744/210012254-234538ff-d198-48aa-8964-37e6fd45d227.gif)
-<h1 align="center">Yo , Piyush Bhawsar</h1> 
-<h2 align="center">Passionate MEARN Developer From India</h2>
-<img align="right" alt="Coding" width="400" src="https://image.myanimelist.net/ui/_3fYL8i6Q-n-155t3dn_4hksVs3MIJxHadG7A7FI_oTy9pL-UqrC-cycJtDkuZzC"
+**backend & genai lead [@dukaan](https://mydukaan.io)** · building (& breaking) software from delhi
 
-[![](https://visitcount.itsvg.in/api?id=piyushhhxyz&icon=0&color=6)](https://visitcount.itsvg.in)
-<!-- <p align="left"> <img src="https://komarev.com/ghpvc/?username=piyushbhawsar&label=Profile%20views&color=000000&style=flat" alt="piyushbhawsar" /> </p>-->
+i like shipping fast, automating everything, and going deep on distributed systems + LLMs.
+previously built things at **scaler**, **sundial**, and **inodesoft**.
 
-# 💫 About Piyush:
-🔭 I’m currently working on API & Testing<br>👯 I’m looking to collaborate on MEARN <br>🌱 I’m currently learning TypeScript and MySQL<br>💬 Ask me about JavaScript , Api's<br>⚡ Fun fact  I Code Daily 💫
-
-<h3 align="left">Connect With Piyush:</h3>
-<p align="left">
-<a href="https://twitter.com/piyush" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/twitter.svg" alt="piyush" height="30" width="40" /></a>
-<a href="https://linkedin.com/in/peeyush ." target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/linked-in-alt.svg" alt="peeyush ." height="30" width="40" /></a>
-<a href="https://codeforces.com/profile/" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/codeforces.svg" alt="" height="30" width="40" /></a>
-<a href="https://www.leetcode.com/" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/leet-code.svg" alt="" height="30" width="40" /></a>
-</p>
-
-<h3 align="left">Languages and Tools:</h3>
-<p align="left"> <a href="https://angular.io" target="_blank" rel="noreferrer"> <img src="https://angular.io/assets/images/logos/angular/angular.svg" alt="angular" width="40" height="40"/> </a> <a href="https://www.arduino.cc/" target="_blank" rel="noreferrer"> <img src="https://cdn.worldvectorlogo.com/logos/arduino-1.svg" alt="arduino" width="40" height="40"/> </a><a href="https://www.w3schools.com/cpp/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/cplusplus/cplusplus-original.svg" alt="cplusplus" width="40" height="40"/> </a> <a href="https://www.docker.com/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/docker/docker-original-wordmark.svg" alt="docker" width="40" height="40"/> </a> <a href="https://expressjs.com" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/express/express-original-wordmark.svg" alt="express" width="40" height="40"/> </a> <a href="https://www.figma.com/" target="_blank" rel="noreferrer"> <img src="https://www.vectorlogo.zone/logos/figma/figma-icon.svg" alt="figma" width="40" height="40"/> </a> <a href="https://flask.palletsprojects.com/" target="_blank" rel="noreferrer"> <img src="https://www.vectorlogo.zone/logos/pocoo_flask/pocoo_flask-icon.svg" alt="flask" width="40" height="40"/> </a> <a href="https://cloud.google.com" target="_blank" rel="noreferrer"> <img src="https://www.vectorlogo.zone/logos/google_cloud/google_cloud-icon.svg" alt="gcp" width="40" height="40"/> </a> <a href="https://git-scm.com/" target="_blank" rel="noreferrer"> <img src="https://www.vectorlogo.zone/logos/git-scm/git-scm-icon.svg" alt="git" width="40" height="40"/> </a> <a href="https://golang.org" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/go/go-original.svg" alt="go" width="40" height="40"/> </a> <a href="https://graphql.org" target="_blank" rel="noreferrer"> <img src="https://www.vectorlogo.zone/logos/graphql/graphql-icon.svg" alt="graphql" width="40" height="40"/> </a> <a href="https://www.adobe.com/in/products/illustrator.html" target="_blank" rel="noreferrer"> <img src="https://www.vectorlogo.zone/logos/adobe_illustrator/adobe_illustrator-icon.svg" alt="illustrator" width="40" height="40"/> </a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/javascript/javascript-original.svg" alt="javascript" width="40" height="40"/> </a> <a href="https://jekyllrb.com/" target="_blank" rel="noreferrer"> <img src="https://www.vectorlogo.zone/logos/jekyllrb/jekyllrb-icon.svg" alt="jekyll" width="40" height="40"/> </a> <a href="https://www.jenkins.io" target="_blank" rel="noreferrer"> <img src="https://www.vectorlogo.zone/logos/jenkins/jenkins-icon.svg" alt="jenkins" width="40" height="40"/> </a> <a href="https://kubernetes.io" target="_blank" rel="noreferrer"> <img src="https://www.vectorlogo.zone/logos/kubernetes/kubernetes-icon.svg" alt="kubernetes" width="40" height="40"/> </a> <a href="https://www.linux.org/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/linux/linux-original.svg" alt="linux" width="40" height="40"/> </a> <a href="https://mariadb.org/" target="_blank" rel="noreferrer"> <img src="https://www.vectorlogo.zone/logos/mariadb/mariadb-icon.svg" alt="mariadb" width="40" height="40"/> </a> <a href="https://middlemanapp.com/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/leungwensen/svg-icon/b84b3f3a3da329b7c1d02346865f8e98beb05413/dist/svg/logos/middleman.svg" alt="middleman" width="40" height="40"/> </a> <a href="https://mochajs.org" target="_blank" rel="noreferrer"> <img src="https://www.vectorlogo.zone/logos/mochajs/mochajs-icon.svg" alt="mocha" width="40" height="40"/> </a> <a href="https://www.mongodb.com/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/mongodb/mongodb-original-wordmark.svg" alt="mongodb" width="40" height="40"/> </a> <a href="https://www.microsoft.com/en-us/sql-server" target="_blank" rel="noreferrer"> <img src="https://www.svgrepo.com/show/303229/microsoft-sql-server-logo.svg" alt="mssql" width="40" height="40"/> </a> <a href="https://www.mysql.com/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/mysql/mysql-original-wordmark.svg" alt="mysql" width="40" height="40"/> </a> <a href="https://nodejs.org" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/nodejs/nodejs-original-wordmark.svg" alt="nodejs" width="40" height="40"/> </a> <a href="https://www.oracle.com/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/oracle/oracle-original.svg" alt="oracle" width="40" height="40"/> </a> <a href="https://www.postgresql.org" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/postgresql/postgresql-original-wordmark.svg" alt="postgresql" width="40" height="40"/> </a> <a href="https://postman.com" target="_blank" rel="noreferrer"> <img src="https://www.vectorlogo.zone/logos/getpostman/getpostman-icon.svg" alt="postman" width="40" height="40"/> </a> <a href="https://github.com/puppeteer/puppeteer" target="_blank" rel="noreferrer"> <img src="https://www.vectorlogo.zone/logos/pptrdev/pptrdev-official.svg" alt="puppeteer" width="40" height="40"/> </a> <a href="https://www.python.org" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/python/python-original.svg" alt="python" width="40" height="40"/> </a> <a href="https://rubyonrails.org" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/rails/rails-original-wordmark.svg" alt="rails" width="40" height="40"/> </a> <a href="https://reactjs.org/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/react/react-original-wordmark.svg" alt="react" width="40" height="40"/> </a> <a href="https://realm.io/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/bestofjs/bestofjs-webui/8665e8c267a0215f3159df28b33c365198101df5/public/logos/realm.svg" alt="realm" width="40" height="40"/> </a> <a href="https://sculpin.io/" target="_blank" rel="noreferrer"> <img src="https://gist.githubusercontent.com/vivek32ta/c7f7bf583c1fb1c58d89301ea40f37fd/raw/1782aef8672484698c0dd407f900c4a329ed5bc4/sculpin.svg" alt="sculpin" width="40" height="40"/> </a> <a href="https://www.selenium.dev" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/detain/svg-logos/780f25886640cef088af994181646db2f6b1a3f8/svg/selenium-logo.svg" alt="selenium" width="40" height="40"/> </a> <a href="https://tailwindcss.com/" target="_blank" rel="noreferrer"> <img src="https://www.vectorlogo.zone/logos/tailwindcss/tailwindcss-icon.svg" alt="tailwind" width="40" height="40"/> </a> <a href="https://travis-ci.org" target="_blank" rel="noreferrer"> <img src="https://www.vectorlogo.zone/logos/travis-ci/travis-ci-icon.svg" alt="travisci" width="40" height="40"/> </a> <a href="https://www.typescriptlang.org/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/typescript/typescript-original.svg" alt="typescript" width="40" height="40"/> </a> <a href="https://www.adobe.com/products/xd.html" target="_blank" rel="noreferrer"> <img src="https://cdn.worldvectorlogo.com/logos/adobe-xd.svg" alt="xd" width="40" height="40"/> </a> </p>
-
-
-
-
-# 📊 GitHub Stats:
-![](https://github-readme-stats.vercel.app/api?username=piyushhhxyz&theme=nightowl&hide_border=false&include_all_commits=true&count_private=false)<br/>
-![](https://github-readme-streak-stats.herokuapp.com/?user=piyushhhxyz&theme=nightowl&hide_border=false)<br/>
-![](https://github-readme-stats.vercel.app/api/top-langs/?username=piyushhhxyz&theme=nightowl&hide_border=false&include_all_commits=true&count_private=false&layout=compact)
-
-
-### ✍️ Dev Quote
-![](https://quotes-github-readme.vercel.app/api?type=horizontal&theme=radical)
+studying computer engineering @ **dtu**.
 
 ---
 
+### what i'm working with
+
+```
+languages    typescript · javascript · python · go · rust · c
+backend      node.js · express · fastapi · graphql
+frontend     react · tailwind
+data         postgresql · mongodb · mysql · redis
+infra        docker · kubernetes · gcp · linux
+ai/ml        openai · whisper · llm integrations
+tools        git · postman · selenium · puppeteer
+```
+
+---
+
+### stuff i've built
+
+| project | what it does |
+|---|---|
+| [**AirAgents**](https://github.com/piyushhhxyz/AirAgents) | airdrop your AI agents |
+| [**NarrationGPT**](https://github.com/piyushhhxyz/NarrationGPT) | AI-powered movie script & synopsis generator |
+| [**GetSet-OA.com**](https://github.com/piyushhhxyz/GetSet-OA.com) | community platform for online assessment pooling |
+| [**Whisper API**](https://github.com/piyushhhxyz/whisper-api-in-docker-container) | whisper speech-to-text API in a docker container |
+| [**SPINDER**](https://github.com/piyushhhxyz/SPINDER) | spotify + tinder -- music-based social matching |
+| [**StudyNotion**](https://github.com/piyushhhxyz/StudyNotion-An-EdTech-Platform) | full-stack ed-tech learning platform |
+| [**not_instagram**](https://github.com/piyushhhxyz/not_instagram) | social app with a twist |
+
+---
+
+### connect
+
+[![LinkedIn](https://img.shields.io/badge/-piyush100x-0A66C2?style=flat&logo=linkedin&logoColor=white)](https://linkedin.com/in/piyush100x)
+[![Peerlist](https://img.shields.io/badge/-piyush100x-00AA45?style=flat&logo=peerlist&logoColor=white)](https://peerlist.io/piyush100x)
+[![X](https://img.shields.io/badge/-@piyushhhxyz-000?style=flat&logo=x&logoColor=white)](https://x.com/piyushhhxyz)
+
+---
+
+<details>
+<summary>github stats</summary>
+<br>
+
+![stats](https://github-readme-stats.vercel.app/api?username=piyushhhxyz&theme=github_dark&hide_border=true&include_all_commits=true&count_private=true&show_icons=true)
+
+![streak](https://github-readme-streak-stats.herokuapp.com/?user=piyushhhxyz&theme=github-dark-blue&hide_border=true)
+
+![langs](https://github-readme-stats.vercel.app/api/top-langs/?username=piyushhhxyz&theme=github_dark&hide_border=true&layout=compact&count_private=true)
+
+</details>


### PR DESCRIPTION
## What changed

Rewrote the profile README from scratch to be modern, clean, and accurate.

### Removed
- Giant animated GIF header
- Wall of 35+ tool/language icons (many not reflected in actual repos)
- Broken social links (twitter.com/piyush, linkedin.com/in/peeyush, empty leetcode/codeforces)
- Emoji-heavy "About Piyush" section
- Random dev quote widget
- Visit counter badge

### Added
- Clean intro with current role (Backend & GenAI Lead @ Dukaan), education (DTU), and previous companies
- Compact code-block tech stack -- only tools backed by actual repo usage (verified against 104 public repos via GitHub API)
- Projects table highlighting 7 best original repos with descriptions
- Correct social badges (LinkedIn, Peerlist, X) with proper handles
- GitHub stats in a collapsible `<details>` section
- Dark theme (`github_dark`) throughout

### Design philosophy
Lean and honest -- no filler, no broken links, no tools you don't actually use. Everything on the page is either verifiable from your repos or your public profiles.

## Testing

**Markdown rendering**: Verified the README renders correctly on GitHub:
- All 7 project links resolve to valid repos
- Social badge URLs use proper shields.io format
- GitHub stats widgets use valid themes (`github_dark`, `github-dark-blue`)
- `<details>` collapsible section is valid HTML for GitHub markdown
- Code block tech stack renders with proper monospace alignment

**Content accuracy**: Cross-referenced tech stack against actual repo languages (104 public repos scanned via GitHub API). Removed tools not backed by repo evidence (Next.js, LangChain, LangGraph were cut from earlier drafts).

**Link validation**: All external links verified -- mydukaan.io, linkedin.com/in/piyush100x, peerlist.io/piyush100x, x.com/piyushhhxyz.