### PR TITLE
Enhance healthz endpoint with uptime/timestamp and graceful shutdown

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -3,7 +3,11 @@ const express = require("express");
 const app = express();
 
 app.get("/healthz", (_req, res) => {
-  res.status(200).json({ status: "ok" });
+  res.status(200).json({
+    status: "ok",
+    uptime: process.uptime(),
+    timestamp: new Date().toISOString(),
+  });
 });
 
 module.exports = app;

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,10 @@ function shutdown(signal) {
     console.log("Server closed");
     process.exit(0);
   });
+  setTimeout(() => {
+    console.error("Forcefully shutting down after timeout");
+    process.exit(1);
+  }, 10_000).unref();
 }
 
 process.on("SIGTERM", () => shutdown("SIGTERM"));

--- a/src/index.js
+++ b/src/index.js
@@ -6,4 +6,15 @@ const server = app.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}`);
 });
 
+function shutdown(signal) {
+  console.log(`${signal} received – shutting down`);
+  server.close(() => {
+    console.log("Server closed");
+    process.exit(0);
+  });
+}
+
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));
+
 module.exports = server;

--- a/tests/healthz.test.js
+++ b/tests/healthz.test.js
@@ -24,8 +24,11 @@ describe("GET /healthz", () => {
     const res = await request(app).get("/healthz");
     const after = new Date().toISOString();
     expect(res.body.timestamp).toBeDefined();
-    expect(res.body.timestamp >= before).toBe(true);
-    expect(res.body.timestamp <= after).toBe(true);
+    // Validate it's a proper ISO-8601 string that round-trips cleanly
+    expect(new Date(res.body.timestamp).toISOString()).toBe(res.body.timestamp);
+    // Compare as numeric timestamps for clarity
+    expect(Date.parse(res.body.timestamp)).toBeGreaterThanOrEqual(Date.parse(before));
+    expect(Date.parse(res.body.timestamp)).toBeLessThanOrEqual(Date.parse(after));
   });
 
   it("returns 404 for unknown routes", async () => {

--- a/tests/healthz.test.js
+++ b/tests/healthz.test.js
@@ -2,15 +2,30 @@ const request = require("supertest");
 const app = require("../src/app");
 
 describe("GET /healthz", () => {
-  it("returns 200 with { status: 'ok' }", async () => {
+  it("returns 200 with status ok", async () => {
     const res = await request(app).get("/healthz");
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ status: "ok" });
+    expect(res.body.status).toBe("ok");
   });
 
   it("returns JSON content-type", async () => {
     const res = await request(app).get("/healthz");
     expect(res.headers["content-type"]).toMatch(/application\/json/);
+  });
+
+  it("includes uptime as a number", async () => {
+    const res = await request(app).get("/healthz");
+    expect(typeof res.body.uptime).toBe("number");
+    expect(res.body.uptime).toBeGreaterThanOrEqual(0);
+  });
+
+  it("includes a valid ISO timestamp", async () => {
+    const before = new Date().toISOString();
+    const res = await request(app).get("/healthz");
+    const after = new Date().toISOString();
+    expect(res.body.timestamp).toBeDefined();
+    expect(res.body.timestamp >= before).toBe(true);
+    expect(res.body.timestamp <= after).toBe(true);
   });
 
   it("returns 404 for unknown routes", async () => {


### PR DESCRIPTION
## Summary

Enhance the Express health check server with richer `/healthz` response data and production-ready graceful shutdown handling.

### Changes

- **`src/app.js`** -- `/healthz` now returns `uptime` (seconds since process start) and `timestamp` (ISO-8601 current time) alongside `status: "ok"`
- **`src/index.js`** -- Added SIGTERM/SIGINT graceful shutdown with a 10-second force-exit timeout guard to prevent indefinite hangs from keep-alive connections
- **`tests/healthz.test.js`** -- Expanded from 3 to 5 unit tests covering the new response fields, with strict ISO-8601 round-trip validation and numeric timestamp comparisons

## Testing

### Unit Tests (5/5 passed)

Command: `npm test`

```
PASS tests/healthz.test.js
  GET /healthz
    ✓ returns 200 with status ok             (16 ms)
    ✓ returns JSON content-type              (3 ms)
    ✓ includes uptime as a number            (2 ms)
    ✓ includes a valid ISO timestamp         (2 ms)
    ✓ returns 404 for unknown routes         (3 ms)

Tests: 5 passed, 5 total   Time: 0.303s
```

### Integration / Manual Tests (8/8 passed)

| # | Test | Result | Evidence |
|---|------|--------|----------|
| 1 | HTTP 200 on `GET /healthz` | PASS | `HTTP Status: 200` |
| 2 | `Content-Type: application/json` | PASS | `Content-Type: application/json; charset=utf-8` |
| 3 | All 3 fields present and typed correctly | PASS | `status:"ok"`, `uptime:20.955` (float >= 0), `timestamp:"2026-05-10T22:57:19.298Z"` (valid ISO-8601) |
| 4 | Uptime advances; timestamp is current and advances | PASS | delta=4.026s over a 4s sleep; T1=22:57:27.075Z < T2=22:57:31.101Z |
| 5 | 404 on unknown routes | PASS | `/unknown` -> 404, `/health` -> 404 |
| 6 | SIGTERM graceful shutdown | PASS | Logs: `SIGTERM received - shutting down` -> `Server closed`; process exited cleanly |
| 7 | SIGINT graceful shutdown | PASS | Logs: `SIGINT received - shutting down` -> `Server closed`; process exited cleanly |
| 8 | In-flight request completes before shutdown | PASS | curl exit 0, full response body received; server only exited after flushing response |
