### PR TITLE
Add graceful shutdown, 405 handler, and expanded healthz tests

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -6,4 +6,8 @@ app.get("/healthz", (_req, res) => {
   res.status(200).json({ status: "ok" });
 });
 
+app.all("/healthz", (_req, res) => {
+  res.status(405).set("Allow", "GET, HEAD").json({ error: "Method Not Allowed" });
+});
+
 module.exports = app;

--- a/src/index.js
+++ b/src/index.js
@@ -6,4 +6,15 @@ const server = app.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}`);
 });
 
+function shutdown(signal) {
+  console.log(`${signal} received \u2013 shutting down`);
+  server.close(() => {
+    console.log("Server closed");
+    process.exit(0);
+  });
+}
+
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));
+
 module.exports = server;

--- a/src/index.js
+++ b/src/index.js
@@ -6,12 +6,22 @@ const server = app.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}`);
 });
 
+let isShuttingDown = false;
+
 function shutdown(signal) {
+  if (isShuttingDown) return;
+  isShuttingDown = true;
+
   console.log(`${signal} received \u2013 shutting down`);
   server.close(() => {
     console.log("Server closed");
     process.exit(0);
   });
+
+  setTimeout(() => {
+    console.error("Forcing shutdown \u2013 timed out waiting for connections to close");
+    process.exit(1);
+  }, 10_000).unref();
 }
 
 process.on("SIGTERM", () => shutdown("SIGTERM"));

--- a/tests/healthz.test.js
+++ b/tests/healthz.test.js
@@ -17,4 +17,14 @@ describe("GET /healthz", () => {
     const res = await request(app).get("/unknown");
     expect(res.status).toBe(404);
   });
+
+  it("responds to HEAD /healthz", async () => {
+    const res = await request(app).head("/healthz");
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 404 for POST /healthz", async () => {
+    const res = await request(app).post("/healthz");
+    expect(res.status).toBe(404);
+  });
 });

--- a/tests/healthz.test.js
+++ b/tests/healthz.test.js
@@ -1,7 +1,7 @@
 const request = require("supertest");
 const app = require("../src/app");
 
-describe("GET /healthz", () => {
+describe("healthz endpoint", () => {
   it("returns 200 with { status: 'ok' }", async () => {
     const res = await request(app).get("/healthz");
     expect(res.status).toBe(200);
@@ -23,8 +23,9 @@ describe("GET /healthz", () => {
     expect(res.status).toBe(200);
   });
 
-  it("returns 404 for POST /healthz", async () => {
+  it("returns 405 for POST /healthz", async () => {
     const res = await request(app).post("/healthz");
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(405);
+    expect(res.headers["allow"]).toBe("GET, HEAD");
   });
 });


### PR DESCRIPTION
## Summary

Improves the Express `/healthz` server with production-ready graceful shutdown and better HTTP semantics.

### Changes

**`src/index.js` -- Graceful shutdown**
- Added SIGTERM/SIGINT signal handlers that call `server.close()` for graceful connection draining
- Added 10-second forced-exit timeout with `.unref()` to prevent hanging on undrained connections
- Added `isShuttingDown` re-entry guard to prevent `ERR_SERVER_NOT_RUNNING` errors from double signals

**`src/app.js` -- 405 Method Not Allowed**
- Added `app.all("/healthz")` catch-all that returns `405 Method Not Allowed` with `Allow: GET, HEAD` header for unsupported HTTP methods (previously returned 404)

**`tests/healthz.test.js` -- Expanded test coverage**
- Added HEAD /healthz test (verifies Express automatic HEAD support)
- Added POST /healthz test (verifies 405 status and Allow header)
- Renamed describe block from `"GET /healthz"` to `"healthz endpoint"` to reflect broader scope

## Testing

### Unit Tests (`npm test`)

```
$ npm test

PASS tests/healthz.test.js
  healthz endpoint
    ✓ returns 200 with { status: 'ok' } (17 ms)
    ✓ returns JSON content-type (4 ms)
    ✓ returns 404 for unknown routes (3 ms)
    ✓ responds to HEAD /healthz (2 ms)
    ✓ returns 405 for POST /healthz (3 ms)

Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
```

### Integration Tests (curl)

| Check | Command | Result |
|---|---|---|
| GET /healthz status | `curl -si localhost:3000/healthz` | `200 OK` -- PASS |
| GET /healthz body | `curl -s localhost:3000/healthz` | `{"status":"ok"}` -- PASS |
| Content-Type header | `curl -w "%{content_type}" localhost:3000/healthz` | `application/json; charset=utf-8` -- PASS |
| HEAD /healthz | `curl -sI localhost:3000/healthz` | `200 OK`, no body -- PASS |
| GET /unknown | `curl -si localhost:3000/unknown` | `404 Not Found` -- PASS |
| POST /healthz | `curl -si -X POST localhost:3000/healthz` | `405 Method Not Allowed` + `Allow: GET, HEAD` -- PASS |
| PORT env override | `PORT=4000 node src/index.js` + `curl :4000/healthz` | `200 OK` -- PASS |

### Graceful Shutdown Tests

| Scenario | Signal | Result |
|---|---|---|
| SIGTERM | `kill -SIGTERM $PID` | Logged shutdown message, exited code 0, port released -- PASS |
| SIGINT | `kill -SIGINT $PID` | Logged shutdown message, exited code 0, port released -- PASS |
| Double SIGTERM (re-entry guard) | Two rapid SIGTERMs | Only one shutdown log line, exited code 0 -- PASS |

### Note

The testing agent identified a pre-existing gap: starting a second instance on an occupied port crashes with an unhandled `EADDRINUSE` error. This is not introduced by this branch and is out of scope.
