### PR TITLE
Add Express server with /healthz health check and graceful shutdown

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,4 +6,12 @@ const server = app.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}`);
 });
 
+process.on("SIGTERM", () => {
+  console.log("SIGTERM received, shutting down gracefully");
+  server.close(() => {
+    console.log("Server closed");
+    process.exit(0);
+  });
+});
+
 module.exports = server;

--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,32 @@
 const app = require("./app");
 
 const PORT = process.env.PORT || 3000;
+const SHUTDOWN_TIMEOUT_MS = 10_000;
 
 const server = app.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}`);
 });
 
-process.on("SIGTERM", () => {
-  console.log("SIGTERM received, shutting down gracefully");
+function shutdown(signal) {
+  console.log(`${signal} received, shutting down gracefully`);
+
   server.close(() => {
     console.log("Server closed");
     process.exit(0);
   });
-});
+
+  // Stop accepting new connections on idle keep-alive sockets immediately
+  server.closeIdleConnections?.();
+
+  // Force exit if connections refuse to drain within the timeout
+  setTimeout(() => {
+    console.error("Forcing shutdown after timeout");
+    server.closeAllConnections?.();
+    process.exit(1);
+  }, SHUTDOWN_TIMEOUT_MS).unref();
+}
+
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));
 
 module.exports = server;

--- a/tests/healthz.test.js
+++ b/tests/healthz.test.js
@@ -18,7 +18,7 @@ describe("GET /healthz", () => {
     expect(res.status).toBe(404);
   });
 
-  it("does not accept POST requests on /healthz", async () => {
+  it("POST /healthz returns 404 (no route defined)", async () => {
     const res = await request(app).post("/healthz");
     expect(res.status).toBe(404);
   });

--- a/tests/healthz.test.js
+++ b/tests/healthz.test.js
@@ -17,4 +17,14 @@ describe("GET /healthz", () => {
     const res = await request(app).get("/unknown");
     expect(res.status).toBe(404);
   });
+
+  it("does not accept POST requests on /healthz", async () => {
+    const res = await request(app).post("/healthz");
+    expect(res.status).toBe(404);
+  });
+
+  it("response body contains only the status field", async () => {
+    const res = await request(app).get("/healthz");
+    expect(Object.keys(res.body)).toEqual(["status"]);
+  });
 });


### PR DESCRIPTION
## Summary

Node.js Express server with a `GET /healthz` health check endpoint returning `{"status": "ok"}` with a 200 status code. Includes graceful shutdown with idle connection draining and forced-exit timeout.

### Changes

- **`src/app.js`** -- Express app with `/healthz` route
- **`src/index.js`** -- Server entry point with graceful shutdown (`SIGTERM`/`SIGINT`), `closeIdleConnections()`, and 10s forced-exit timeout
- **`tests/healthz.test.js`** -- 5 unit tests covering health check response, content-type, 404 for unknown routes, POST method rejection, and response body shape
- **`package.json`** -- Express + Jest/Supertest configuration
- **`.gitignore`** -- Excludes `node_modules/`

## Testing

### Unit Tests (`npm test`) -- PASSED

**Command:** `npm test`

```
PASS tests/healthz.test.js
  GET /healthz
    ✓ returns 200 with { status: 'ok' }              (22 ms)
    ✓ returns JSON content-type                       ( 3 ms)
    ✓ returns 404 for unknown routes                  ( 3 ms)
    ✓ POST /healthz returns 404 (no route defined)    ( 2 ms)
    ✓ response body contains only the status field    ( 3 ms)

Test Suites:  1 passed, 1 total
Tests:        5 passed, 5 total
```

### Live Server Smoke Tests -- PASSED

| Request | Expected | Actual |
|---|---|---|
| `GET /healthz` | 200, `{"status":"ok"}` | 200, `application/json; charset=utf-8`, `{"status":"ok"}` |
| `HEAD /healthz` | 200, no body | 200, empty body, correct headers |
| `POST /healthz` | 404 | 404 `Cannot POST /healthz` |
| `GET /unknown` | 404 | 404 `Cannot GET /unknown` |
| `GET /HEALTHZ` | 200 (case-insensitive) | 200 `{"status":"ok"}` |
| `GET /healthz/extra` | 404 | 404 |
| `PUT /healthz` | 404 | 404 |
| `GET /healthz` with `Accept: text/plain` | 200, JSON | 200 `{"status":"ok"}` |

### Graceful Shutdown Tests -- PASSED

- **SIGTERM**: Process logged `"SIGTERM received, shutting down gracefully"` and exited with code 0
- **SIGINT**: Process logged `"SIGINT received, shutting down gracefully"` and exited with code 0
