### PR TITLE
Enhance /healthz endpoint with uptime and timestamp

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -3,7 +3,11 @@ const express = require("express");
 const app = express();
 
 app.get("/healthz", (_req, res) => {
-  res.status(200).json({ status: "ok" });
+  res.status(200).json({
+    status: "ok",
+    uptime: process.uptime(),
+    timestamp: new Date().toISOString(),
+  });
 });
 
 module.exports = app;

--- a/tests/healthz.test.js
+++ b/tests/healthz.test.js
@@ -2,7 +2,7 @@ const request = require("supertest");
 const app = require("../src/app");
 
 describe("GET /healthz", () => {
-  it("returns 200 with { status: 'ok' }", async () => {
+  it("returns 200 with status ok", async () => {
     const res = await request(app).get("/healthz");
     expect(res.status).toBe(200);
     expect(res.body.status).toBe("ok");

--- a/tests/healthz.test.js
+++ b/tests/healthz.test.js
@@ -5,12 +5,25 @@ describe("GET /healthz", () => {
   it("returns 200 with { status: 'ok' }", async () => {
     const res = await request(app).get("/healthz");
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ status: "ok" });
+    expect(res.body.status).toBe("ok");
   });
 
   it("returns JSON content-type", async () => {
     const res = await request(app).get("/healthz");
     expect(res.headers["content-type"]).toMatch(/application\/json/);
+  });
+
+  it("includes uptime as a number", async () => {
+    const res = await request(app).get("/healthz");
+    expect(typeof res.body.uptime).toBe("number");
+    expect(res.body.uptime).toBeGreaterThanOrEqual(0);
+  });
+
+  it("includes a valid ISO timestamp", async () => {
+    const res = await request(app).get("/healthz");
+    expect(res.body.timestamp).toBeDefined();
+    const parsed = new Date(res.body.timestamp);
+    expect(parsed.toISOString()).toBe(res.body.timestamp);
   });
 
   it("returns 404 for unknown routes", async () => {


### PR DESCRIPTION
## Summary

Enhances the existing `GET /healthz` health check endpoint to return additional operational metadata alongside the `status: "ok"` field:

- **`uptime`** -- server uptime in seconds via `process.uptime()`
- **`timestamp`** -- current UTC time as an ISO 8601 string via `new Date().toISOString()`

Example response:
```json
{
  "status": "ok",
  "uptime": 123.456,
  "timestamp": "2025-05-11T00:34:03.015Z"
}
```

The change is purely additive -- the existing `status: "ok"` contract is preserved.

## Changes

| File | Change |
|---|---|
| `src/app.js` | Added `uptime` and `timestamp` fields to the `/healthz` response |
| `tests/healthz.test.js` | Updated existing assertion to field-level check; added 2 new test cases for `uptime` and `timestamp` |

## Testing

### Unit Tests (Jest + Supertest)

**Command:** `npm test`

**Result:** 5/5 passed, exit code 0

| # | Test | Result | Time |
|---|---|---|---|
| 1 | `returns 200 with status ok` | PASS | 16 ms |
| 2 | `returns JSON content-type` | PASS | 3 ms |
| 3 | `includes uptime as a number` | PASS | 2 ms |
| 4 | `includes a valid ISO timestamp` | PASS | 2 ms |
| 5 | `returns 404 for unknown routes` | PASS | 4 ms |

### Manual Verification

Started the server and hit the endpoint directly:

```
$ node -e "..." # start server on port 3099, GET /healthz
Status: 200
Body: { status: 'ok', uptime: 0.083237091, timestamp: '2026-05-11T00:34:03.015Z' }
```

Confirmed correct status code, JSON content-type, and all three fields present with valid values.
