### PR TITLE
Improve healthz endpoint: add uptime field and graceful shutdown

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -3,7 +3,7 @@ const express = require("express");
 const app = express();
 
 app.get("/healthz", (_req, res) => {
-  res.status(200).json({ status: "ok" });
+  res.status(200).json({ status: "ok", uptime: process.uptime() });
 });
 
 module.exports = app;

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,10 @@ function shutdown(signal) {
     console.log("Server closed");
     process.exit(0);
   });
+  setTimeout(() => {
+    console.error("Forcefully shutting down");
+    process.exit(1);
+  }, 10_000).unref();
 }
 
 process.on("SIGTERM", () => shutdown("SIGTERM"));

--- a/src/index.js
+++ b/src/index.js
@@ -6,4 +6,15 @@ const server = app.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}`);
 });
 
+function shutdown(signal) {
+  console.log(`${signal} received – shutting down`);
+  server.close(() => {
+    console.log("Server closed");
+    process.exit(0);
+  });
+}
+
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));
+
 module.exports = server;

--- a/tests/healthz.test.js
+++ b/tests/healthz.test.js
@@ -5,7 +5,13 @@ describe("GET /healthz", () => {
   it("returns 200 with { status: 'ok' }", async () => {
     const res = await request(app).get("/healthz");
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ status: "ok" });
+    expect(res.body.status).toBe("ok");
+  });
+
+  it("includes uptime as a number", async () => {
+    const res = await request(app).get("/healthz");
+    expect(typeof res.body.uptime).toBe("number");
+    expect(res.body.uptime).toBeGreaterThanOrEqual(0);
   });
 
   it("returns JSON content-type", async () => {


### PR DESCRIPTION
## Summary

Improves the Express health check server with two enhancements:

1. **Uptime in `/healthz` response** -- the endpoint now returns `{ status: "ok", uptime: <seconds> }` so consumers can see how long the process has been running.
2. **Graceful shutdown** -- SIGTERM and SIGINT handlers cleanly close the HTTP server before exiting, with a 10-second forced-exit timeout as a safety net against hung connections.

## Changes

| File | Change |
|---|---|
| `src/app.js` | Added `uptime: process.uptime()` to the health check response |
| `src/index.js` | Added `shutdown()` handler for SIGTERM/SIGINT with 10s forced-exit timeout |
| `tests/healthz.test.js` | Updated status assertion, added new test for uptime field |

## Testing

### Unit Tests
- **Command:** `npm test` (runs `jest --verbose`)
- **Result:** 4/4 tests passed

```
PASS tests/healthz.test.js
  GET /healthz
    ✓ returns 200 with { status: 'ok' } (16 ms)
    ✓ includes uptime as a number (3 ms)
    ✓ returns JSON content-type (3 ms)
    ✓ returns 404 for unknown routes (3 ms)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
```

### Test Coverage
- `returns 200 with { status: 'ok' }` -- validates core endpoint contract
- `includes uptime as a number` -- validates new uptime field type and range
- `returns JSON content-type` -- regression guard for response serialization
- `returns 404 for unknown routes` -- ensures no accidental wildcard routes

### Code Quality
- Simplify agent: approved, no issues
- Review agent: approved, no issues
- Build agent: applied forced-shutdown timeout suggestion from simplify review
