### PR TITLE
Improve Express healthz server: uptime, logging, graceful shutdown

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2,8 +2,18 @@ const express = require("express");
 
 const app = express();
 
+// Simple request logger
+app.use((req, _res, next) => {
+  console.log(`${new Date().toISOString()} ${req.method} ${req.url}`);
+  next();
+});
+
+// Health check endpoint
 app.get("/healthz", (_req, res) => {
-  res.status(200).json({ status: "ok" });
+  res.status(200).json({
+    status: "ok",
+    uptime: process.uptime(),
+  });
 });
 
 module.exports = app;

--- a/src/index.js
+++ b/src/index.js
@@ -6,4 +6,16 @@ const server = app.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}`);
 });
 
+// Graceful shutdown
+function shutdown(signal) {
+  console.log(`${signal} received – shutting down`);
+  server.close(() => {
+    console.log("Server closed");
+    process.exit(0);
+  });
+}
+
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));
+
 module.exports = server;

--- a/src/index.js
+++ b/src/index.js
@@ -7,12 +7,26 @@ const server = app.listen(PORT, () => {
 });
 
 // Graceful shutdown
+let shuttingDown = false;
+
 function shutdown(signal) {
+  if (shuttingDown) {
+    console.log(`${signal} received again – already shutting down`);
+    return;
+  }
+  shuttingDown = true;
+
   console.log(`${signal} received – shutting down`);
   server.close(() => {
     console.log("Server closed");
     process.exit(0);
   });
+
+  // Force exit if server.close() hangs (e.g. keep-alive connections)
+  setTimeout(() => {
+    console.error("Forced shutdown after timeout");
+    process.exit(1);
+  }, 10_000).unref();
 }
 
 process.on("SIGTERM", () => shutdown("SIGTERM"));

--- a/tests/healthz.test.js
+++ b/tests/healthz.test.js
@@ -2,10 +2,16 @@ const request = require("supertest");
 const app = require("../src/app");
 
 describe("GET /healthz", () => {
-  it("returns 200 with { status: 'ok' }", async () => {
+  it("returns 200 with status ok", async () => {
     const res = await request(app).get("/healthz");
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ status: "ok" });
+    expect(res.body.status).toBe("ok");
+  });
+
+  it("includes uptime as a number", async () => {
+    const res = await request(app).get("/healthz");
+    expect(typeof res.body.uptime).toBe("number");
+    expect(res.body.uptime).toBeGreaterThanOrEqual(0);
   });
 
   it("returns JSON content-type", async () => {


### PR DESCRIPTION
## Summary

Improves the Express healthz server with production-readiness features:

- **Uptime field** in `/healthz` response — returns `process.uptime()` alongside `status: "ok"`
- **Request logger middleware** — logs `<ISO-timestamp> <METHOD> <URL>` for every incoming request
- **Graceful shutdown** — listens for `SIGTERM`/`SIGINT`, drains connections via `server.close()`, with a 10-second forced-exit timeout and duplicate-signal guard

## Changes

| File | What changed |
|------|-------------|
| `src/app.js` | Added request logger middleware; added `uptime` field to `/healthz` response |
| `src/index.js` | Added graceful shutdown with `SIGTERM`/`SIGINT` handlers, forced-exit timeout, duplicate-signal guard |
| `tests/healthz.test.js` | Added test for `uptime` field; updated assertions to tolerate extra response fields |

## Testing

### Unit Tests (`npm test`)

```
PASS tests/healthz.test.js
  GET /healthz
    ✓ returns 200 with status ok        (28 ms)
    ✓ includes uptime as a number        (5 ms)
    ✓ returns JSON content-type          (4 ms)
    ✓ returns 404 for unknown routes     (4 ms)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
```

### Integration Tests (live server)

**Request logger verification:**
- `curl /healthz` → `{"status":"ok","uptime":1.005701539}` with log line `2026-05-11T23:42:33.701Z GET /healthz` -- PASS
- `curl /unknown` → Express 404 with log line `2026-05-11T23:42:33.911Z GET /unknown` -- PASS

**Graceful shutdown:**

| Test | Result |
|------|--------|
| SIGTERM → clean shutdown | exit 0 -- PASS |
| SIGINT → clean shutdown | exit 0 -- PASS |
| Duplicate signal guard (two rapid SIGTERMs) | No double-exit -- PASS |
| Forced-exit timeout (open socket held) | exit 1 after timeout -- PASS |
